### PR TITLE
Use WebRequest instead of HttpClient

### DIFF
--- a/Constants/HttpClientConstants.cs
+++ b/Constants/HttpClientConstants.cs
@@ -1,7 +1,0 @@
-namespace NLogFlake.Constants;
-
-internal static class HttpClientConstants
-{
-    internal const int PostTimeoutSeconds = 3;
-    internal const string ClientName = "LogFlakeClient";
-}

--- a/Extensions/WebResponseExtensions.cs
+++ b/Extensions/WebResponseExtensions.cs
@@ -1,0 +1,18 @@
+using System.Net;
+
+namespace NLogFlake.Extensions;
+
+public static class WebResponseExtensions
+{
+    public static bool IsSuccessStatusCode(this WebResponse webResponse)
+    {
+        if (webResponse is HttpWebResponse httpWebResponse)
+        {
+            int statusCode = (int)httpWebResponse.StatusCode;
+
+            return statusCode >= 200 && statusCode <= 299;
+        }
+
+        return false;
+    }
+}

--- a/Factories/IWebRequestFactory.cs
+++ b/Factories/IWebRequestFactory.cs
@@ -1,0 +1,8 @@
+using System.Net;
+
+namespace NLogFlake.Factories;
+
+public interface IWebRequestFactory
+{
+    HttpWebRequest Create(string queueName);
+}

--- a/Factories/WebRequestFactory.cs
+++ b/Factories/WebRequestFactory.cs
@@ -1,0 +1,35 @@
+using System.Net;
+using System.Net.Mime;
+using Microsoft.Extensions.Options;
+using NLogFlake.Models.Options;
+
+namespace NLogFlake.Factories;
+
+internal class WebRequestFactory : IWebRequestFactory
+{
+    private const string UriTemplate = "api/ingestion/{0}";
+    private const int PostTimeoutMilliseconds = 3000;
+    private const string UserAgent = "logflake-client-netcore/1.8.3";
+
+    private readonly Uri _requestUri;
+
+    public WebRequestFactory(IOptions<LogFlakeOptions> options)
+    {
+        _requestUri = new(
+            baseUri: new(options.Value.Endpoint),
+            relativeUri: string.Format(UriTemplate, options.Value.AppId));
+    }
+
+    public HttpWebRequest Create(string queueName)
+    {
+        HttpWebRequest httpWebRequest = WebRequest.CreateHttp($"{_requestUri}/{queueName}");
+
+        httpWebRequest.Accept = MediaTypeNames.Application.Json;
+        httpWebRequest.ContentType = MediaTypeNames.Application.Octet;
+        httpWebRequest.Method = WebRequestMethods.Http.Post;
+        httpWebRequest.Timeout = PostTimeoutMilliseconds;
+        httpWebRequest.UserAgent = UserAgent;
+
+        return httpWebRequest;
+    }
+}

--- a/IServiceCollectionExtensions.cs
+++ b/IServiceCollectionExtensions.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using NLogFlake.Constants;
+using NLogFlake.Factories;
 using NLogFlake.Models.Options;
 using NLogFlake.Services;
 
@@ -16,18 +16,11 @@ public static class IServiceCollectionExtensions
 
         services.TryAddSingleton<IVersionService, VersionService>();
 
-        services.AddHttpClient(HttpClientConstants.ClientName, ConfigureClient);
+        services.TryAddSingleton<IWebRequestFactory, WebRequestFactory>();
 
         services.AddSingleton<ILogFlake, LogFlake>();
         services.AddSingleton<ILogFlakeService, LogFlakeService>();
 
         return services;
-    }
-
-    private static void ConfigureClient(HttpClient client)
-    {
-        client.Timeout = TimeSpan.FromSeconds(HttpClientConstants.PostTimeoutSeconds);
-        client.DefaultRequestHeaders.Add("Accept", "application/json");
-        client.DefaultRequestHeaders.Add("User-Agent", "logflake-client-netcore/1.8.3");
     }
 }

--- a/LogFlake.csproj
+++ b/LogFlake.csproj
@@ -28,7 +28,6 @@
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageReference Include="Snappier" Version="1.1.6" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />


### PR DESCRIPTION
Using `WebRequest` instead of `HttpClient` will prevent users that uses `ILogger` to have an infinite loop. 