### PR TITLE
Mark project as discontinued

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+> [!WARNING]
+> **This project has been discontinued.**
+>
+> LogFlake was decommissioned in August 2026. This repository is archived and read-only:
+> it receives no further development, bug fixes or security updates.
+> The published package is deprecated — please do not use it in new projects.
+
 # LogFlake Client .NET Core ![Version](https://img.shields.io/badge/version-1.8.3-blue.svg?cacheSeconds=2592000)
 
 > This repository contains the sources for the client-side components of the LogFlake product suite for applications logs and performance collection for .NET applications.


### PR DESCRIPTION
LogFlake is being decommissioned. Adds the end-of-life notice to the README before the repository is archived.